### PR TITLE
Fix failing tests

### DIFF
--- a/src/Password.php
+++ b/src/Password.php
@@ -30,7 +30,7 @@ class Password
 
     public function __toString()
     {
-        return '*******';
+        return '********';
     }
 
     public function matchesHash(string $hash) : bool

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -30,8 +30,10 @@
 namespace Org_Heigl\PaswordTest;
 
 use Org_Heigl\Password\Password;
+use PHPUnit\Framework\Error\Warning;
+use PHPUnit\Framework\TestCase;
 
-class PasswordTest extends \PHPUnit_Framework_TestCase
+class PasswordTest extends TestCase
 {
 
     public function testShouldBeRehashed()
@@ -52,7 +54,15 @@ class PasswordTest extends \PHPUnit_Framework_TestCase
     {
         $password = Password::createFromPlainText('test');
 
-        self::assertSame('test', $password->getPlainTextPasswordAndYesIKnowWhatIAmDoingHere());
+        self::assertSame('test', @$password->getPlainTextPasswordAndYesIKnowWhatIAmDoingHere());
+    }
+
+    public function testGetPlainTextPasswordAndYesIKnowWhatIAmDoingHereTriggersWarning()
+    {
+        $password = Password::createFromPlainText('test');
+
+        $this->expectException(Warning::class);
+        $password->getPlainTextPasswordAndYesIKnowWhatIAmDoingHere();
     }
 
     public function testMatchesHash()
@@ -64,7 +74,7 @@ class PasswordTest extends \PHPUnit_Framework_TestCase
     {
         $password = Password::createFromPlainText('test');
 
-        self::assertAttributeSame('tests', 'password', $password);
+        self::assertAttributeSame('test', 'password', $password);
         self::assertAttributeSame(null, 'hash', $password);
     }
 


### PR DESCRIPTION
* PHPUnit 7.1 only has namespaced testcase class
* Mismatch in number of '*' between implementation and test
* Typo in test value
* Suppress warning, separately test for it being triggered