### PR TITLE
Prevent leaking password through var_dump or print_r

### DIFF
--- a/src/Password.php
+++ b/src/Password.php
@@ -33,6 +33,13 @@ class Password
         return '********';
     }
 
+    public function __debugInfo()
+    {
+        return [
+            'password' => '********'
+        ];
+    }
+
     public function matchesHash(string $hash) : bool
     {
         $this->hash = $hash;

--- a/src/Password.php
+++ b/src/Password.php
@@ -30,7 +30,7 @@ class Password
 
     public function __toString()
     {
-        return '*******';
+        return '********';
     }
 
     public function matchesHash(string $hash) : bool

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -30,8 +30,10 @@
 namespace Org_Heigl\PaswordTest;
 
 use Org_Heigl\Password\Password;
+use PHPUnit\Framework\Error\Warning;
+use PHPUnit\Framework\TestCase;
 
-class PasswordTest extends \PHPUnit_Framework_TestCase
+class PasswordTest extends TestCase
 {
 
     public function testShouldBeRehashed()
@@ -52,7 +54,15 @@ class PasswordTest extends \PHPUnit_Framework_TestCase
     {
         $password = Password::createFromPlainText('test');
 
-        self::assertSame('test', $password->getPlainTextPasswordAndYesIKnowWhatIAmDoingHere());
+        self::assertSame('test', @$password->getPlainTextPasswordAndYesIKnowWhatIAmDoingHere());
+    }
+
+    public function testGetPlainTextPasswordAndYesIKnowWhatIAmDoingHereTriggersWarning()
+    {
+        $password = Password::createFromPlainText('test');
+
+        $this->expectException(Warning::class);
+        $password->getPlainTextPasswordAndYesIKnowWhatIAmDoingHere();
     }
 
     public function testMatchesHash()
@@ -64,7 +74,7 @@ class PasswordTest extends \PHPUnit_Framework_TestCase
     {
         $password = Password::createFromPlainText('test');
 
-        self::assertAttributeSame('tests', 'password', $password);
+        self::assertAttributeSame('test', 'password', $password);
         self::assertAttributeSame(null, 'hash', $password);
     }
 

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -82,4 +82,22 @@ class PasswordTest extends TestCase
     {
 
     }
+
+    public function testDoesNotLeakPasswordThroughPrintR()
+    {
+        $password = Password::createFromPlainText('test');
+
+        self::assertNotContains('test', print_r($password, true));
+    }
+
+    public function testDoesNotLeakPasswordThroughVarDump()
+    {
+        $password = Password::createFromPlainText('test');
+
+        ob_start();
+        var_dump($password);
+        $output = ob_get_clean();
+
+        self::assertNotContains('test', $output);
+    }
 }


### PR DESCRIPTION
By overriding the __debugInfo magic method, exposure of the plaintext
password through a var_dump or print_r call can be prevented.

http://php.net/manual/en/language.oop5.magic.php#object.debuginfo

---

Note: This PR is based on the test fixes in #2, so that one probably needs to be merged first.